### PR TITLE
fix spelling

### DIFF
--- a/velin/ref.py
+++ b/velin/ref.py
@@ -624,7 +624,7 @@ def reformat_file(data, filename, compact, unsafe, fail=False):
                         + str(secs2),
                     )
         except Exception as e:
-            print(f"somethign went wrong with {filename}:{docstring}")
+            print(f"something went wrong with {filename}:{docstring}")
             if fail:
                 raise
             continue


### PR DESCRIPTION
I apparently have many docstrings with non-numpydoc sections in them so I keep running into seeing that.