### PR TITLE
Ensure `--check` fails if there are missing arguments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 .pytest_cache/
 *.ipynb
 dist
+
+__pycache__


### PR DESCRIPTION
ran into this again (apparently I did back in february https://github.com/Carreau/velin/issues/20)

and this is a workaround until the auto changes are fully implemented. But maybe could also be a useful way to fail for cases where it's ambiguous what to do. Then there needs to be a way to signal that a file needs changes even if velin doesn't know what to do with it.